### PR TITLE
Change `created_at` and `updated_at` to use standard `INT` column type

### DIFF
--- a/zendesk.install
+++ b/zendesk.install
@@ -505,12 +505,14 @@ function zendesk_schema() {
       ),
       'created_at' => array(
         'type' => 'int',
-        'length' => 255,
+        'size' => 'normal',
+        'unsigned' => FALSE,
         'not null' => TRUE,
       ),
       'updated_at' => array(
-        'type' => 'varchar',
-        'length' => 255,
+        'type' => 'int',
+        'size' => 'normal',
+        'unsigned' => FALSE,
         'not null' => TRUE,
       ),
     ),
@@ -621,6 +623,17 @@ function zendesk_update_7105() {
   db_create_table('zendesk_jira_links', $schema['zendesk_jira_links']);
 
   return "Created Zendesk/JIRA links table.";
+}
+
+/**
+ * Add the Zendesk/JIRA Links table.
+ */
+function zendesk_update_7106() {
+    $schema = zendesk_schema();
+    db_change_field('zendesk_jira_links', 'created_at', 'created_at', $schema['zendesk_jira_links']['fields']['created_at']);
+    db_change_field('zendesk_jira_links', 'updated_at', 'updated_at', $schema['zendesk_jira_links']['fields']['updated_at']);
+
+    return "Corrected timestamp columns in Zendesk/JIRA links table.";
 }
 
 /**


### PR DESCRIPTION
Currently, the `created_at` column is `INT`, but `updated_at` was `VARCHAR`. I updated it so both would be `INT` with `'size' => 'normal', 'unsigned' => FALSE`. We may need to alter the worker that inserts data into the db, because it looks like `created_at` is just including the year and `updated_at` has the full ISO timestamp, despite supposedly using `strtotime` before saving those column.